### PR TITLE
Fix crash when marshalling byte arrays or NativeMemory to JS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
            prebuild -t 14.16.0 --include-regex "\.(node|a|dll|so|dylib)$";           
            prebuild -t 11.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
            prebuild -t 12.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
+           prebuild -t 13.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
          fi
        # TODO: Why is process.env.DEBUG set when building production?
        - "cd ../electron-blazor-glue"
@@ -89,6 +90,7 @@ jobs:
            prebuild -t 14.16.0 --include-regex "\.(node|a|dll|so|dylib)$";           
            prebuild -t 11.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
            prebuild -t 12.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
+           prebuild -t 13.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
          fi
       script:
        - npm run build-testapp
@@ -115,10 +117,11 @@ jobs:
        - npm ci --build-from-source
        - if [ "$TRAVIS_TAG" != "" ]; then
            npm version "${TRAVIS_TAG:1}" --allow-same-version;
-           prebuild -t 12.17.0 --include-regex "\.(node|a|dll|so|dylib)$";
-           prebuild -t 14.16.0 --include-regex "\.(node|a|dll|so|dylib)$";           
-           prebuild -t 11.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
-           prebuild -t 12.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib)$";
+           prebuild -t 12.17.0 --include-regex "\.(node|a|dll|so|dylib|pdb)$";
+           prebuild -t 14.16.0 --include-regex "\.(node|a|dll|so|dylib|pdb)$";           
+           prebuild -t 11.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib|pdb)$";
+           prebuild -t 12.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib|pdb)$";
+           prebuild -t 13.0.0 -r electron --include-regex "\.(node|a|dll|so|dylib|pdb)$";
          fi
       script:
        - npm run build-testapp

--- a/coreclr-hosting/cppsrc/context.h
+++ b/coreclr-hosting/cppsrc/context.h
@@ -34,8 +34,6 @@ class Context {
   Napi::ThreadSafeFunction dotnet_thread_safe_callback_;
   void (*closing_runtime_)(void);
 
-  std::map<uint8_t*, BufferCache*> buffers_;
-
   Context(const Context&) = delete;
   Context& operator=(const Context&) = delete;  // no self-assignments
   Context(std::unique_ptr<DotNetHost> dotnet_host, Napi::Env env);

--- a/coreclr-hosting/package.json
+++ b/coreclr-hosting/package.json
@@ -34,7 +34,8 @@
     "mocha": "mocha -s 0",
     "prepare": "npm run build",
     "install": "prebuild-install || npm run rebuild",
-    "prebuild-node": "node node_modules/prebuild/bin.js -t 12.16.3 --include-regex \"\\.(node|a|dll|so|dylib)$\""
+    "prebuild-node": "node node_modules/prebuild/bin.js -t 12.16.3 --include-regex \"\\.(node|a|dll|so|dylib)$\"",
+    "prebuild-electron": "prebuild -t 12.0.0 -r electron --include-regex \"\\.(node|a|dll|so|dylib|pdb)$\""
   },
   "author": "Daniel Martin",
   "license": "MIT",

--- a/examples/electron-blazor/package.json
+++ b/examples/electron-blazor/package.json
@@ -14,7 +14,8 @@
     "build-blazorapp": "dotnet build  BlazorApp/BlazorApp.csproj",
     "build": "npm run build-service && npm run build-blazorapp",
     "start": "npm run build && electron .",
-    "electron": "electron ."
+    "electron": "electron .",
+    "electron-rebuild-debug": "electron-rebuild --debug"
   },
   "author": "Daniel Martin",
   "license": "MIT",


### PR DESCRIPTION
The crash was due to the JS garbage collector cleaning up the marshalled buffer that was being reused.
The fix is to simply copy the memory, which is slower but much simpler.

This commit also includes PDBs in Windows releases for better crash dump analysis.